### PR TITLE
KIE bench에 사용될 [VLM (DocEV DP) -> LLM information extraction] 파이프라인 구축

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ lmms_eval/tasks/mlvu/__pycache__/utils.cpython-310.pyc
 scripts/
 .env
 UpScore_results/
+temp_images/

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ scripts/
 .env
 UpScore_results/
 temp_images/
+sample_outputs/

--- a/README.md
+++ b/README.md
@@ -53,7 +53,25 @@ scripts/run_eval.sh \
 - Dataset 전처리 (KIE-bench -> KIE-bench huggingface version)
     - 주의: 이를 통해 생성된 KIE-bench huggingface version에는 일부 정보가 실제 Upstage huggingface uploaded version과 다를 수 있습니다. (다른 부분은 코드 참고) 하지만 사용되지 않는 부분이기에 최신 버전의 KIE bench를 빠르게 적용하기 위해 전처리 코드를 작성하였습니다. 최신 버전의 KIE-bench가 huggingface에 업로드 되어 있는 경우, 해당 데이터를 다운로드 받아 사용하시기 바랍니다.
     ```
-    # 1. 코드 내 base_path 변수 수정
+    # 1. 아래 경로의 코드 내 base_path 변수 수정
     # 2. 아래 코드 실행
     python preprocessor/KIE_bench_to_HF_dataset.py
     ```
+
+- VLM_LLM_IE 모델 실행
+    - `VLM_LLM_IE` 는 table caption 평가를 위해 VLM inference -> LLM inference 형태의 두번의 인퍼런스를 통해 information extraction을 수행하는 모듈입니다. `vllm` API inference 형식으로 구현하였습니다.  
+    - 실행 방법
+        1. `UpstageAI/docev-data-engine` repo를 참고하여 필요한 모델의 vllm server를 실행합니다.
+        2. 아래 예시 코드를 변형하여 실행합니다. vllm server 실행시 사용한 configuration과 동일해야합니다.
+        ```
+        bash scripts/run_eval_VLM_LLM_IE.sh \
+            --vlm_model_name "Qwen/Qwen2.5-VL-32B-Instruct" \
+            --llm_model_name "deepseek-ai/DeepSeek-R1-Distill-Qwen-32B" \
+            --vlm_port 8002 \
+            --llm_port 8005 \
+            --vlm_host "192.168.1.5" \
+            --llm_host "192.168.1.5" \
+            --vlm_max_tokens 32768 \
+            --llm_max_tokens 32768 \
+            --port 35000
+        ```

--- a/lmms_eval/models/VLM_LLM_IE.py
+++ b/lmms_eval/models/VLM_LLM_IE.py
@@ -50,8 +50,8 @@ class VLM_LLM_IE(lmms):
         eval_logger.info(f"VLM prompt key: {self.vlm_prompt_key}")
 
         # 2. 모델 초기화 (DP 사용시 각 모델 포트 번호 증가)
-        self.vlm_client = BaseClient(vlm_model_name, vlm_host, vlm_port, vlm_max_completion_tokens)
-        self.llm_client = BaseClient(llm_model_name, llm_host, llm_port, llm_max_completion_tokens)
+        self.vlm_client = BaseClient(vlm_model_name, vlm_host, vlm_port, max_completion_tokens=vlm_max_completion_tokens)
+        self.llm_client = BaseClient(llm_model_name, llm_host, llm_port, max_completion_tokens=llm_max_completion_tokens)
         
 
     def generate_until(self, requests: List[Instance]) -> List[str]:

--- a/lmms_eval/models/VLM_LLM_IE.py
+++ b/lmms_eval/models/VLM_LLM_IE.py
@@ -69,7 +69,6 @@ class VLM_LLM_IE(lmms):
     async def _async_generate_until(self, requests: List[Instance]) -> List[str]:
         """비동기 처리를 위한 내부 메소드"""
         total = len(requests)
-        results = [None] * total
         
         # 프로그레스바 (메인 프로세스에서만 표시)
         pbar = tqdm(total=total, disable=(self._rank != 0), desc="Processing")
@@ -93,11 +92,7 @@ class VLM_LLM_IE(lmms):
         completed_results = await asyncio.gather(*tasks)
         pbar.close()
         
-        # 결과 정렬 (인덱스 순서대로)
-        for result in completed_results:
-            idx = result["idx"]
-            results[idx] = result["llm_response"]
-            
+        results = [result["llm_response"] for result in completed_results]
         return results
 
     async def _process_single_request(self, request, idx, total, progress_bar=None):

--- a/lmms_eval/models/VLM_LLM_IE.py
+++ b/lmms_eval/models/VLM_LLM_IE.py
@@ -45,25 +45,10 @@ class VLM_LLM_IE(lmms):
     ) -> None:
         super().__init__()
         assert batch_size == 1, "batch_size must be 1"
-        self.threads = threads
-
-        # 1. accelerator 초기화
-        accelerator = Accelerator()
-        if accelerator.num_processes > 1:
-            assert accelerator.distributed_type in [DistributedType.FSDP, DistributedType.MULTI_GPU, DistributedType.DEEPSPEED], "Unsupported distributed type provided. Only DDP and FSDP are supported."
-            self.accelerator = accelerator
-            if self.accelerator.is_local_main_process:
-                eval_logger.info(f"Using {accelerator.num_processes} devices with data parallelism")
-            self._rank = self.accelerator.local_process_index
-            self._world_size = self.accelerator.num_processes
-        else:
-            self.accelerator = accelerator
-            self._rank = self.accelerator.local_process_index
-            self._world_size = self.accelerator.num_processes
 
         # 2. 모델 초기화 (DP 사용시 각 모델 포트 번호 증가)
-        self.vlm_client = BaseClient(vlm_model_name, vlm_host, vlm_port+self._rank, vlm_max_completion_tokens)
-        self.llm_client = BaseClient(llm_model_name, llm_host, llm_port+self._rank, llm_max_completion_tokens)
+        self.vlm_client = BaseClient(vlm_model_name, vlm_host, vlm_port, vlm_max_completion_tokens)
+        self.llm_client = BaseClient(llm_model_name, llm_host, llm_port, llm_max_completion_tokens)
         
 
     def generate_until(self, requests: List[Instance]) -> List[str]:

--- a/lmms_eval/models/VLM_LLM_IE.py
+++ b/lmms_eval/models/VLM_LLM_IE.py
@@ -3,7 +3,8 @@ import json
 from concurrent.futures import ThreadPoolExecutor
 from io import BytesIO
 from typing import List, Optional, Tuple, Union
-
+import os
+import asyncio
 import numpy as np
 from accelerate import Accelerator, DistributedType
 from loguru import logger as eval_logger
@@ -64,11 +65,11 @@ class VLM_LLM_IE(lmms):
         self.vlm_client = BaseClient(vlm_model_name, vlm_host, vlm_port+self._rank, vlm_max_completion_tokens)
         self.llm_client = BaseClient(llm_model_name, llm_host, llm_port+self._rank, llm_max_completion_tokens)
         
-    def generate_until(self, requests: List[Instance]) -> List[str]:
-        # TODO: async inferece 구현. VLM 인퍼런스를 모두 기다릴 필요 없이, VLM 인퍼런스 완료 한 객체는 바로 LLM 인퍼런스 시작
 
+    def generate_until(self, requests: List[Instance]) -> List[str]:
         """
-        Process requests through this model, then feed the outputs to a second model.
+        Process requests through VLM model and then LLM model asynchronously.
+        VLM 인퍼런스 완료된 요청은 즉시 LLM 인퍼런스로 넘어갑니다.
         
         Args:
             requests: List of Instance objects for the first model
@@ -76,65 +77,92 @@ class VLM_LLM_IE(lmms):
         Returns:
             List of final text outputs from the second model
         """
-
-
-        # === 1. loop 돌면서 VLM 모델 inference ===
-        vlm_res = []
-        pbar = tqdm(total=len(requests), disable=(self.rank != 0), desc="VLM Responding")
-        for request in requests:
-            # 1.1 데이터 처리
-            context_dict, gen_kwargs, doc_to_visual, doc_id, task, split = request.arguments
-            context_dict = json.loads(context_dict)
-            image_url_list = doc_to_visual(self.task_dict[task][split][doc_id])
-
-            vlm_user_prompt = context_dict["vlm_user_prompt"]
-
-            # 2.2 VLM 모델 inference
-            response_vlm = self.vlm_client.run(system_prompt=None, user_prompt=vlm_user_prompt, image_url_list=image_url_list)
-
-            # 2.3 데이터 저장
-            vlm_res.append(response_vlm)
-            pbar.update(1)
-        pbar.close()
-
-        # === 3. LLM 모델에 넣기 위한 데이터 처리 ===
-        llm_res = []
-        pbar = tqdm(total=len(requests), disable=(self.rank != 0), desc="LLM Responding")
+        # 비동기 이벤트 루프 실행
+        results = asyncio.run(self._async_generate_until(requests))
+        return results
+    
+    async def _async_generate_until(self, requests: List[Instance]) -> List[str]:
+        """비동기 처리를 위한 내부 메소드"""
+        total = len(requests)
+        results = [None] * total
+        
+        # 프로그레스바 (메인 프로세스에서만 표시)
+        pbar = tqdm(total=total, disable=(self._rank != 0), desc="Processing")
+        
+        # 동시 실행 제한을 위한 세마포어 (최대 4개의 async 요청 동시 실행. vllm server에 동시에 수백~수천개의 인퍼런스 요청이 가지 않도록 제한하는 역할)
+        semaphore = asyncio.Semaphore(4)
+        
+        async def _process_single_request_limited(request, idx, total):
+            async with semaphore:
+                return await self._process_single_request(request, idx, total, pbar)
+        
+        # 모든 요청에 대해 비동기 처리 시작
+        tasks = []
         for idx, request in enumerate(requests):
-            # 3.1 데이터 처리
-            context_dict, gen_kwargs, doc_to_visual, doc_id, task, split = request.arguments
-            context_dict = json.loads(context_dict)
-
-            # 3.2 vlm output을 이용해 LLM 입력 프롬프트 생성
-            llm_pre_prompt = context_dict["llm_pre_prompt"]
-            llm_post_prompt = context_dict["llm_post_prompt"]
-            schema = context_dict["schema"]
-            prompt = f"{vlm_res[idx]}{llm_pre_prompt}{schema}{llm_post_prompt}"
-            
-            # 3.3 LLM 모델 inference
-            # TODO: structured output 사용 (https://docs.vllm.ai/en/latest/features/structured_outputs.html) -> pydantic json_schema
-            llm_response = self.llm_client.run(system_prompt=None, user_prompt=prompt, image_url_list=[])
-            llm_res.append(llm_response)
-
-            pbar.update(1)
+            task = asyncio.create_task(
+                _process_single_request_limited(request, idx, total)
+            )
+            tasks.append(task)
+        
+        # 완료된 태스크 결과 수집
+        completed_results = await asyncio.gather(*tasks)
         pbar.close()
-
-        # === 4. save sample outputs ===
-        # os.makedirs("sample_outputs", exist_ok=True)
-        # for idx, request in enumerate(requests):
-        #     context_dict, gen_kwargs, doc_to_visual, doc_id, task, split = request.arguments
-        #     context_dict = json.loads(context_dict)
-        #     save_dict = {
-        #         "llm_output": llm_res[idx],
-        #         "vlm_output": vlm_res[idx],
-        #         "context_dict": context_dict,
-        #         "doc_id": doc_id,
-        #         "doc": self.task_dict[task][split][doc_id]
-        #     }
-        #     with open(f"sample_outputs/{idx}.json", "w") as f:
-        #         json.dump(save_dict, f)
+        
+        # 결과 정렬 (인덱스 순서대로)
+        for result in completed_results:
+            idx = result["idx"]
+            results[idx] = result["llm_response"]
             
-        return llm_res
+        return results
+
+    async def _process_single_request(self, request, idx, total, progress_bar=None):
+        """비동기적으로 단일 요청 처리: VLM -> LLM 순서로 인퍼런스 진행"""
+        # 1. 데이터 처리
+        context_dict, gen_kwargs, doc_to_visual, doc_id, task, split = request.arguments
+        context_dict = json.loads(context_dict)
+        image_url_list = doc_to_visual(self.task_dict[task][split][doc_id])
+        vlm_user_prompt = context_dict["vlm_user_prompt"]
+
+        # 2. VLM 모델 인퍼런스
+        vlm_response = self.vlm_client.run(system_prompt=None, user_prompt=vlm_user_prompt, image_url_list=image_url_list)
+        
+        if progress_bar:
+            progress_bar.set_description(f"VLM [{idx+1}/{total}] completed & LLM [{idx}/{total}] completed")
+
+        # 3. VLM 출력을 기반으로 LLM 입력 프롬프트 생성
+        llm_pre_prompt = context_dict["llm_pre_prompt"]
+        llm_post_prompt = context_dict["llm_post_prompt"]
+        schema = context_dict["schema"]
+        prompt = f"{vlm_response}{llm_pre_prompt}{schema}{llm_post_prompt}"
+        
+        # 4. LLM 모델 인퍼런스
+        llm_response = self.llm_client.run(system_prompt=None, user_prompt=prompt, image_url_list=[])
+        
+        if progress_bar:
+            progress_bar.set_description(f"VLM [{idx+1}/{total}] completed & LLM [{idx+1}/{total}] completed")
+            progress_bar.update(1)
+        
+        # 5. 결과 및 샘플 저장
+        os.makedirs("sample_outputs", exist_ok=True)
+        save_dict = {
+            "llm_output": llm_response,
+            "vlm_output": vlm_response,
+            "context_dict": context_dict,
+            "doc_id": doc_id,
+            "doc": self.task_dict[task][split][doc_id],
+            "vlm_user_prompt": context_dict["vlm_user_prompt"],
+            "llm_user_prompt": f"{vlm_response}{context_dict['llm_pre_prompt']}{context_dict['schema']}{context_dict['llm_post_prompt']}"
+        }
+        with open(f"sample_outputs/{idx}.json", "w") as f:
+            json.dump(save_dict, f)
+            
+        return {
+            "idx": idx,
+            "vlm_response": vlm_response,
+            "llm_response": llm_response,
+        }
+
+    
 
     def _set_gen_kwargs(self, gen_kwargs):
         if "max_new_tokens" not in gen_kwargs:

--- a/lmms_eval/models/VLM_LLM_IE.py
+++ b/lmms_eval/models/VLM_LLM_IE.py
@@ -1,0 +1,192 @@
+import base64
+import json
+from concurrent.futures import ThreadPoolExecutor
+from io import BytesIO
+from typing import List, Optional, Tuple, Union
+
+import numpy as np
+from accelerate import Accelerator, DistributedType
+from loguru import logger as eval_logger
+from PIL import Image
+from tqdm import tqdm
+from lmms_eval.api.instance import Instance
+from lmms_eval.api.model import lmms
+from lmms_eval.api.registry import register_model
+
+from lmms_eval.models.vllm_client_utils.BaseClient import BaseClient
+
+@register_model("VLM_LLM_IE")
+class VLM_LLM_IE(lmms):
+    """
+    VLM_LLM_IE 모델은 핵심 정보 추출(KIE) 벤치마크를 위한 모델입니다.
+    VLM 모델 인퍼런스, LLM 모델 인퍼런스를 순차적으로 진행합니다.
+
+    vllm 백엔드를 사용하여 VLM, LLM 모델을 구현합니다.
+    - vllm 백엔드 사용 시 vllm에서 구현된 모델들은 새롭게 구현하지 않아도 되는 장점이 있습니다.
+
+    reference: lmms_eval/models/vllm.py
+    """
+
+
+    def __init__(
+        self,
+        vlm_model_name: str,
+        llm_model_name: str,
+        vlm_host: str = "localhost",
+        llm_host: str = "localhost",
+        vlm_port: int = 35001,
+        llm_port: int = 35002,
+        vlm_max_completion_tokens: int = 4096,
+        llm_max_completion_tokens: int = 4096,
+        threads: int = 16,  # Threads to use for decoding visuals
+        batch_size: int = 1,
+        **kwargs,
+    ) -> None:
+        super().__init__()
+        assert batch_size == 1, "batch_size must be 1"
+        self.threads = threads
+
+        # 1. accelerator 초기화
+        accelerator = Accelerator()
+        if accelerator.num_processes > 1:
+            assert accelerator.distributed_type in [DistributedType.FSDP, DistributedType.MULTI_GPU, DistributedType.DEEPSPEED], "Unsupported distributed type provided. Only DDP and FSDP are supported."
+            self.accelerator = accelerator
+            if self.accelerator.is_local_main_process:
+                eval_logger.info(f"Using {accelerator.num_processes} devices with data parallelism")
+            self._rank = self.accelerator.local_process_index
+            self._world_size = self.accelerator.num_processes
+        else:
+            self.accelerator = accelerator
+            self._rank = self.accelerator.local_process_index
+            self._world_size = self.accelerator.num_processes
+
+        # 2. 모델 초기화 (DP 사용시 각 모델 포트 번호 증가)
+        self.vlm_client = BaseClient(vlm_model_name, vlm_host, vlm_port+self._rank, vlm_max_completion_tokens)
+        self.llm_client = BaseClient(llm_model_name, llm_host, llm_port+self._rank, llm_max_completion_tokens)
+        
+    def generate_until(self, requests: List[Instance]) -> List[str]:
+        # TODO: async inferece 구현. VLM 인퍼런스를 모두 기다릴 필요 없이, VLM 인퍼런스 완료 한 객체는 바로 LLM 인퍼런스 시작
+
+        """
+        Process requests through this model, then feed the outputs to a second model.
+        
+        Args:
+            requests: List of Instance objects for the first model
+            
+        Returns:
+            List of final text outputs from the second model
+        """
+
+
+        # === 1. loop 돌면서 VLM 모델 inference ===
+        vlm_res = []
+        pbar = tqdm(total=len(requests), disable=(self.rank != 0), desc="VLM Responding")
+        for request in requests:
+            # 1.1 데이터 처리
+            context_dict, gen_kwargs, doc_to_visual, doc_id, task, split = request.arguments
+            context_dict = json.loads(context_dict)
+            image_url_list = doc_to_visual(self.task_dict[task][split][doc_id])
+
+            vlm_user_prompt = context_dict["vlm_user_prompt"]
+
+            # 2.2 VLM 모델 inference
+            response_vlm = self.vlm_client.run(system_prompt=None, user_prompt=vlm_user_prompt, image_url_list=image_url_list)
+
+            # 2.3 데이터 저장
+            vlm_res.append(response_vlm)
+            pbar.update(1)
+        pbar.close()
+
+        # === 3. LLM 모델에 넣기 위한 데이터 처리 ===
+        llm_res = []
+        pbar = tqdm(total=len(requests), disable=(self.rank != 0), desc="LLM Responding")
+        for idx, request in enumerate(requests):
+            # 3.1 데이터 처리
+            context_dict, gen_kwargs, doc_to_visual, doc_id, task, split = request.arguments
+            context_dict = json.loads(context_dict)
+
+            # 3.2 vlm output을 이용해 LLM 입력 프롬프트 생성
+            llm_pre_prompt = context_dict["llm_pre_prompt"]
+            llm_post_prompt = context_dict["llm_post_prompt"]
+            schema = context_dict["schema"]
+            prompt = f"{vlm_res[idx]}{llm_pre_prompt}{schema}{llm_post_prompt}"
+            
+            # 3.3 LLM 모델 inference
+            # TODO: structured output 사용 (https://docs.vllm.ai/en/latest/features/structured_outputs.html) -> pydantic json_schema
+            llm_response = self.llm_client.run(system_prompt=None, user_prompt=prompt, image_url_list=[])
+            llm_res.append(llm_response)
+
+            pbar.update(1)
+        pbar.close()
+
+        # === 4. save sample outputs ===
+        # os.makedirs("sample_outputs", exist_ok=True)
+        # for idx, request in enumerate(requests):
+        #     context_dict, gen_kwargs, doc_to_visual, doc_id, task, split = request.arguments
+        #     context_dict = json.loads(context_dict)
+        #     save_dict = {
+        #         "llm_output": llm_res[idx],
+        #         "vlm_output": vlm_res[idx],
+        #         "context_dict": context_dict,
+        #         "doc_id": doc_id,
+        #         "doc": self.task_dict[task][split][doc_id]
+        #     }
+        #     with open(f"sample_outputs/{idx}.json", "w") as f:
+        #         json.dump(save_dict, f)
+            
+        return llm_res
+
+    def _set_gen_kwargs(self, gen_kwargs):
+        if "max_new_tokens" not in gen_kwargs:
+            gen_kwargs["max_new_tokens"] = 1024
+        if gen_kwargs["max_new_tokens"] > 4096:
+            gen_kwargs["max_new_tokens"] = 4096
+        if "temperature" not in gen_kwargs:
+            gen_kwargs["temperature"] = 0
+        if "top_p" not in gen_kwargs:
+            gen_kwargs["top_p"] = 0.95
+        return gen_kwargs
+
+    def flatten(self, input):
+        new_list = []
+        for i in input:
+            for j in i:
+                new_list.append(j)
+        return new_list
+
+    def _preprocess_vlm(self, visuals):
+        if 'docev_preview' in self.vlm_pretrained:
+            return visuals
+        else:
+            raise ValueError(f"Unsupported VLM model: {self.vlm_pretrained}")
+        
+    def _preprocess_llm(self, texts):
+        if 'deepseek' in self.llm_pretrained.lower():
+            return texts
+        else:
+            raise ValueError(f"Unsupported LLM model: {self.llm_pretrained}")
+
+    def loglikelihood(self, requests: List[Instance]) -> List[Tuple[float, bool]]:
+        raise NotImplementedError("loglikelihood() is not applicable for VLM-LLM-IE")
+
+    def generate_until_multi_round(self, requests) -> List[str]:
+        raise NotImplementedError("generate_until_multi_round() is not applicable for VLM-LLM-IE")
+
+    def _encode_video(self, video: str):
+        raise NotImplementedError("_encode_video() is not applicable for VLM-LLM-IE")
+
+    def _encode_image(self, image: Union[Image.Image, str]):
+        """
+        Encode the image to base64 string
+        """
+        if isinstance(image, str):
+            img = Image.open(image).convert("RGB")
+        else:
+            img = image.copy()
+
+        output_buffer = BytesIO()
+        img.save(output_buffer, format="PNG")
+        byte_data = output_buffer.getvalue()
+
+        base64_str = base64.b64encode(byte_data).decode("utf-8")
+        return base64_str

--- a/lmms_eval/models/VLM_LLM_IE.py
+++ b/lmms_eval/models/VLM_LLM_IE.py
@@ -132,29 +132,29 @@ class VLM_LLM_IE(lmms):
         # 3. VLM 출력을 기반으로 LLM 입력 프롬프트 생성
         llm_pre_prompt = context_dict["llm_pre_prompt"]
         llm_post_prompt = context_dict["llm_post_prompt"]
-        schema = context_dict["schema"]
-        prompt = f"{vlm_response}{llm_pre_prompt}{schema}{llm_post_prompt}"
+        schema = json.loads(context_dict["schema"])
+        prompt = f"{llm_pre_prompt}{vlm_response}{llm_post_prompt}"
         
         # 4. LLM 모델 인퍼런스
-        llm_response = self.llm_client.run(system_prompt=None, user_prompt=prompt, image_url_list=[])
+        llm_response = self.llm_client.run(system_prompt=None, user_prompt=prompt, image_url_list=[], guided_json=schema)
         
         if progress_bar:
             progress_bar.set_description(f"VLM [{idx+1}/{total}] completed & LLM [{idx+1}/{total}] completed")
             progress_bar.update(1)
         
         # 5. 결과 및 샘플 저장
-        os.makedirs("sample_outputs", exist_ok=True)
-        save_dict = {
-            "llm_output": llm_response,
-            "vlm_output": vlm_response,
-            "context_dict": context_dict,
-            "doc_id": doc_id,
-            "doc": self.task_dict[task][split][doc_id],
-            "vlm_user_prompt": context_dict["vlm_user_prompt"],
-            "llm_user_prompt": f"{vlm_response}{context_dict['llm_pre_prompt']}{context_dict['schema']}{context_dict['llm_post_prompt']}"
-        }
-        with open(f"sample_outputs/{idx}.json", "w") as f:
-            json.dump(save_dict, f)
+        # os.makedirs("sample_outputs", exist_ok=True)
+        # save_dict = {
+        #     "llm_output": llm_response,
+        #     "vlm_output": vlm_response,
+        #     "context_dict": context_dict,
+        #     "doc_id": doc_id,
+        #     "doc": self.task_dict[task][split][doc_id],
+        #     "vlm_user_prompt": context_dict["vlm_user_prompt"],
+        #     "llm_user_prompt": f"{context_dict['llm_pre_prompt']}{vlm_response}{context_dict['llm_post_prompt']}"
+        # }
+        # with open(f"sample_outputs/{idx}.json", "w") as f:
+        #     json.dump(save_dict, f)
             
         return {
             "idx": idx,

--- a/lmms_eval/models/VLM_LLM_IE.py
+++ b/lmms_eval/models/VLM_LLM_IE.py
@@ -46,6 +46,9 @@ class VLM_LLM_IE(lmms):
         super().__init__()
         assert batch_size == 1, "batch_size must be 1"
 
+        self.vlm_prompt_key = "DocEV_DP_user_prompt" if "docev_dp" in vlm_model_name.lower() else "vlm_user_prompt"
+        eval_logger.info(f"VLM prompt key: {self.vlm_prompt_key}")
+
         # 2. 모델 초기화 (DP 사용시 각 모델 포트 번호 증가)
         self.vlm_client = BaseClient(vlm_model_name, vlm_host, vlm_port, vlm_max_completion_tokens)
         self.llm_client = BaseClient(llm_model_name, llm_host, llm_port, llm_max_completion_tokens)
@@ -101,7 +104,7 @@ class VLM_LLM_IE(lmms):
         context_dict, gen_kwargs, doc_to_visual, doc_id, task, split = request.arguments
         context_dict = json.loads(context_dict)
         image_url_list = doc_to_visual(self.task_dict[task][split][doc_id])
-        vlm_user_prompt = context_dict["vlm_user_prompt"]
+        vlm_user_prompt = context_dict[self.vlm_prompt_key]
 
         # 2. VLM 모델 인퍼런스
         vlm_response = self.vlm_client.run(system_prompt=None, user_prompt=vlm_user_prompt, image_url_list=image_url_list)

--- a/lmms_eval/models/VLM_LLM_IE.py
+++ b/lmms_eval/models/VLM_LLM_IE.py
@@ -45,8 +45,8 @@ class VLM_LLM_IE(lmms):
     ) -> None:
         super().__init__()
         assert batch_size == 1, "batch_size must be 1"
-
-        self.vlm_prompt_key = "DocEV_DP_user_prompt" if "docev_dp" in vlm_model_name.lower() else "vlm_user_prompt"
+        use_docev_dp = "docev_dp" in vlm_model_name.lower() or "docevdp" in vlm_model_name.lower() or "docev-dp" in vlm_model_name.lower()
+        self.vlm_prompt_key = "DocEV_DP_user_prompt" if use_docev_dp else "vlm_user_prompt"
         eval_logger.info(f"VLM prompt key: {self.vlm_prompt_key}")
 
         # 2. 모델 초기화 (DP 사용시 각 모델 포트 번호 증가)

--- a/lmms_eval/models/__init__.py
+++ b/lmms_eval/models/__init__.py
@@ -64,6 +64,7 @@ AVAILABLE_MODELS = {
     "xcomposer2_4KHD": "XComposer2_4KHD",
     "xcomposer2d5": "XComposer2D5",
     "egogpt": "EgoGPT",
+    "VLM_LLM_IE": "VLM_LLM_IE",
 }
 
 

--- a/lmms_eval/models/vllm_client_utils/BaseClient.py
+++ b/lmms_eval/models/vllm_client_utils/BaseClient.py
@@ -1,0 +1,76 @@
+"""
+BaseClient는 OpenAI API를 사용하여 모델을 호출하는 기본 클래스입니다.
+본 코드는 VLM_LLM_IE 모델에서 인퍼런스하기 위한 모듈로 사용됩니다.
+
+ref: https://github.com/UpstageAI/docev-data-engine/blob/main/layout_viewer/viewer_inference_util/BaseClient.py
+"""
+
+from typing import List
+from openai import OpenAI
+import base64
+
+class BaseClient:
+    def __init__(self, model_name: str, host: str, port: int, use_system_prompt: bool = False, prompt_image_type: int = 1, max_completion_tokens: int = 4096):
+        self.MODEL = model_name
+        self.use_system_prompt = use_system_prompt
+        self.prompt_image_type = prompt_image_type
+        self.client = OpenAI(
+            base_url=f"http://{host}:{port}/v1",
+            api_key="token-abc123",
+        )
+        self.max_completion_tokens = max_completion_tokens
+    
+    def _convert_image_url_to_chat_completion_format(self, base64_image:str) -> str:
+        """
+        Convert image url to chat completion format
+        """
+        if self.prompt_image_type == 1:
+            return {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": f"data:image/jpeg;base64,{base64_image}"
+                    },
+            }
+        else:
+            raise ValueError(f"Invalid prompt image type: {self.prompt_image_type}")
+
+    def _chat_completion(self, system_prompt:str, user_prompt:str, image_url_list:List[str]):
+        messages = []
+        if system_prompt and self.use_system_prompt:
+            messages.append({
+                "role": "system", 
+                "content": system_prompt
+            })
+        
+        user_content = []
+        if len(image_url_list) > 0 and self.prompt_image_type != -1:
+            for image_url in image_url_list:
+                base64_image = encode_base64_content_from_image(image_url)
+                user_content.append(self._convert_image_url_to_chat_completion_format(base64_image))
+
+        user_content.append({
+            "type": "text",
+            "text": user_prompt
+        })
+
+        messages.append({
+            "role": "user",
+            "content": user_content
+        })
+
+        chat_completion = self.client.chat.completions.create(
+            messages=messages,
+            model=self.MODEL,
+            max_completion_tokens=self.max_completion_tokens,
+            temperature=0,
+        )
+
+        return chat_completion.choices[0].message.content
+
+    def run(self, system_prompt:str, user_prompt:str, image_url_list:List[str]) -> None:
+        result = self._chat_completion(system_prompt=system_prompt, user_prompt=user_prompt, image_url_list=image_url_list)
+        return result
+    
+def encode_base64_content_from_image(image_path: str) -> str:
+    with open(image_path, "rb") as image_file:
+        return base64.b64encode(image_file.read()).decode('utf-8')

--- a/lmms_eval/tasks/KIE_bench/KIE_bench_test_VLM_LLM_IE.yaml
+++ b/lmms_eval/tasks/KIE_bench/KIE_bench_test_VLM_LLM_IE.yaml
@@ -30,8 +30,8 @@ metric_list:
 lmms_eval_specific_kwargs:
   default:
     vlm_user_prompt: "Describe the image as detail as possible. If there is text in the image, write down the text as well. The extracted information should be in order of human reading."
-    llm_pre_prompt: "Extract information from the given image based on this schema: "
-    llm_post_prompt: "\n1. If you cannot find the information or the value is not mentioned, return nothing.\n2. If you can find more than one value for a key, return all the values in an array.\n3. Return the value only if the given key’s value exists in the provided content. If it does not exist, return empty string.\n4. All the results should be formatted exactly same as the schema."
+    llm_pre_prompt: "Content to analyze: "
+    llm_post_prompt: "\n\n1. If you cannot find the information or the value is not mentioned, return nothing.\n2. If you can find more than one value for a key, return all the values in an array.\n3. Return the value only if the given key’s value exists in the provided content. If it does not exist, return empty string."
 metadata:
   - version: 0.0
 

--- a/lmms_eval/tasks/KIE_bench/KIE_bench_test_VLM_LLM_IE.yaml
+++ b/lmms_eval/tasks/KIE_bench/KIE_bench_test_VLM_LLM_IE.yaml
@@ -1,0 +1,41 @@
+task: "KIE_bench_VLM_LLM_IE"
+test_split: test
+
+# Dataset configuration options
+dataset_path: "/app/docfm/datasets/benchmark/key_information_extraction/v3.1_HuggingFace"
+dataset_name: "KIE_bench_VLM_LLM_IE"
+dataset_kwargs: 
+  load_from_disk: true
+process_docs: null
+
+# Prompting / in-context formatting options
+doc_to_visual: !function utils.KIE_bench_doc_to_visual_VLM_LLM_IE
+doc_to_text: !function utils.KIE_bench_doc_to_text_VLM_LLM_IE
+doc_to_target: !function utils.KIE_bench_doc_to_target
+doc_to_choice: null
+
+# Generation settings
+output_type: generate_until
+generation_kwargs: {}
+
+# Post-processing and metrics
+process_results: !function utils.KIE_bench_process_results
+metric_list: 
+  - metric: UpScore
+    aggregation: !function utils.KIE_bench_aggregate_results
+    higher_is_better: true
+    
+
+# Model-specific prompt configurations
+lmms_eval_specific_kwargs:
+  default:
+    vlm_user_prompt: "Describe the image as detail as possible. If there is text in the image, write down the text as well. The extracted information should be in order of human reading."
+    llm_pre_prompt: "Extract information from the given image based on this schema: "
+    llm_post_prompt: "\n1. If you cannot find the information or the value is not mentioned, return nothing.\n2. If you can find more than one value for a key, return all the values in an array.\n3. Return the value only if the given key’s value exists in the provided content. If it does not exist, return empty string.\n4. All the results should be formatted exactly same as the schema."
+metadata:
+  - version: 0.0
+
+
+# Additional metadata
+metadata: 
+  - version: 0.0

--- a/lmms_eval/tasks/KIE_bench/KIE_bench_test_VLM_LLM_IE.yaml
+++ b/lmms_eval/tasks/KIE_bench/KIE_bench_test_VLM_LLM_IE.yaml
@@ -2,8 +2,8 @@ task: "KIE_bench_VLM_LLM_IE"
 test_split: test
 
 # Dataset configuration options
-dataset_path: "/app/docfm/datasets/benchmark/key_information_extraction/v3.1_HuggingFace"
-dataset_name: "KIE_bench_VLM_LLM_IE"
+dataset_path: "/app/docfm/datasets/benchmark/key_information_extraction/v3.1_HuggingFace/"
+dataset_name: "KIE_bench"
 dataset_kwargs: 
   load_from_disk: true
 process_docs: null
@@ -30,6 +30,7 @@ metric_list:
 lmms_eval_specific_kwargs:
   default:
     vlm_user_prompt: "Describe the image as detail as possible. If there is text in the image, write down the text as well. The extracted information should be in order of human reading."
+    DocEV_DP_user_prompt: "Convert the input document image into the structured HTML format of the Upstage Document Parse."
     llm_pre_prompt: "Content to analyze: "
     llm_post_prompt: "\n\n1. If you cannot find the information or the value is not mentioned, return nothing.\n2. If you can find more than one value for a key, return all the values in an array.\n3. Return the value only if the given key’s value exists in the provided content. If it does not exist, return empty string."
 metadata:

--- a/lmms_eval/tasks/KIE_bench/utils.py
+++ b/lmms_eval/tasks/KIE_bench/utils.py
@@ -70,7 +70,7 @@ def KIE_bench_doc_to_text_VLM_LLM_IE(item, lmms_eval_specific_kwargs=None):
     with open(schema_path, "r") as f:
         schema = json.load(f)
 
-    schema_text = str(schema)
+    schema_text = json.dumps(schema) # json.dumps로 변환하여 문자열로 저장
     if "vlm_user_prompt" in lmms_eval_specific_kwargs and lmms_eval_specific_kwargs["vlm_user_prompt"] != "":
         vlm_user_prompt = lmms_eval_specific_kwargs["vlm_user_prompt"]
     else:
@@ -161,7 +161,12 @@ def KIE_bench_process_results(item, results):
     schema_path = item["schema_path"]
     with open(schema_path, "r") as f:
         schema = json.load(f)
-    pred_result = parse_pred_ans(pred, schema)
+    try:
+        # If the prediction is already in json format, use json.loads (structured output of VLM_LLM_IE)
+        pred_result = json.loads(pred)
+    except Exception as e:
+        # If the prediction is not in json format, use parse_pred_ans
+        pred_result = parse_pred_ans(pred, schema)
 
     # Parse ground truth
     gt_path = item["gold_path"]

--- a/lmms_eval/tasks/KIE_bench/utils.py
+++ b/lmms_eval/tasks/KIE_bench/utils.py
@@ -83,12 +83,17 @@ def KIE_bench_doc_to_text_VLM_LLM_IE(item, lmms_eval_specific_kwargs=None):
         llm_post_prompt = lmms_eval_specific_kwargs["llm_post_prompt"]
     else:
         llm_post_prompt = ""
+    if "DocEV_DP_user_prompt" in lmms_eval_specific_kwargs and lmms_eval_specific_kwargs["DocEV_DP_user_prompt"] != "":
+        DocEV_DP_user_prompt = lmms_eval_specific_kwargs["DocEV_DP_user_prompt"]
+    else:
+        DocEV_DP_user_prompt = ""
 
     context_dict = {
         "schema": schema_text,
         "vlm_user_prompt": vlm_user_prompt,
         "llm_pre_prompt": llm_pre_prompt,
-        "llm_post_prompt": llm_post_prompt
+        "llm_post_prompt": llm_post_prompt,
+        "DocEV_DP_user_prompt": DocEV_DP_user_prompt
     }
 
     return json.dumps(context_dict) # string타입만 가능하므로 json.dumps로 우회

--- a/lmms_eval/tasks/KIE_bench/utils.py
+++ b/lmms_eval/tasks/KIE_bench/utils.py
@@ -3,6 +3,7 @@ import json
 import numpy as np
 from PIL import Image
 from pdf2image import convert_from_path
+import uuid
 from pathlib import Path
 import glob
 from typing import Dict, Any, Union
@@ -29,8 +30,30 @@ def KIE_bench_doc_to_visual(item):
         return [image]
     return images
 
+def KIE_bench_doc_to_visual_VLM_LLM_IE(item):
+    """
+    For vllm serving, save the temporary images and return the image paths to the item
+    """
+    image_path = item["file_path"]
+    if image_path.endswith(".pdf"):
+        images = convert_from_path(image_path)
+        os.makedirs("temp_images", exist_ok=True)
+        image_paths = []
+        for image in images:
+            image_path = f"temp_images/{uuid.uuid4()}.png"
+            image.save(image_path)
+            image_paths.append(image_path)
+    else:
+        image = Image.open(image_path).convert("RGB")
+        image_path = f"temp_images/{uuid.uuid4()}.png"
+        image.save(image_path)
+        image_paths = [image_path]
+
+    return image_paths
+
+
+
 def KIE_bench_doc_to_text(item, lmms_eval_specific_kwargs=None):
-    # TODO: apply response_format
     schema_path = item["schema_path"]
     with open(schema_path, "r") as f:
         schema = json.load(f)
@@ -41,6 +64,35 @@ def KIE_bench_doc_to_text(item, lmms_eval_specific_kwargs=None):
         question = f"{question}{lmms_eval_specific_kwargs['post_prompt']}"
 
     return question
+
+def KIE_bench_doc_to_text_VLM_LLM_IE(item, lmms_eval_specific_kwargs=None):
+    schema_path = item["schema_path"]
+    with open(schema_path, "r") as f:
+        schema = json.load(f)
+
+    schema_text = str(schema)
+    if "vlm_user_prompt" in lmms_eval_specific_kwargs and lmms_eval_specific_kwargs["vlm_user_prompt"] != "":
+        vlm_user_prompt = lmms_eval_specific_kwargs["vlm_user_prompt"]
+    else:
+        vlm_user_prompt = ""
+    if "llm_pre_prompt" in lmms_eval_specific_kwargs and lmms_eval_specific_kwargs["llm_pre_prompt"] != "":
+        llm_pre_prompt = lmms_eval_specific_kwargs["llm_pre_prompt"]
+    else:
+        llm_pre_prompt = ""
+    if "llm_post_prompt" in lmms_eval_specific_kwargs and lmms_eval_specific_kwargs["llm_post_prompt"] != "":
+        llm_post_prompt = lmms_eval_specific_kwargs["llm_post_prompt"]
+    else:
+        llm_post_prompt = ""
+
+    context_dict = {
+        "schema": schema_text,
+        "vlm_user_prompt": vlm_user_prompt,
+        "llm_pre_prompt": llm_pre_prompt,
+        "llm_post_prompt": llm_post_prompt
+    }
+
+    return json.dumps(context_dict) # string타입만 가능하므로 json.dumps로 우회
+
 
 def KIE_bench_doc_to_target(item):
     # UpScore 계산에는 사용하지 않습니다.

--- a/scripts/run_eval_VLM_LLM_IE.sh
+++ b/scripts/run_eval_VLM_LLM_IE.sh
@@ -130,5 +130,7 @@ $CMD
 
 # Remove temp images
 echo "Remove temp images"
-rm -r temp_images/*
+if [ -d "temp_images" ]; then
+    rm -r temp_images/*
+fi
 echo "Done"

--- a/scripts/run_eval_VLM_LLM_IE.sh
+++ b/scripts/run_eval_VLM_LLM_IE.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+
+# Default values
+GPU_IDS="0"
+PORT="35000"
+TASKS="KIE_bench_VLM_LLM_IE" 
+MODEL_NAME="VLM_LLM_IE"
+VLM_PORT="35001"
+LLM_PORT="35002"
+VLM_HOST="localhost"
+LLM_HOST="localhost"
+VLM_MAX_TOKENS="32768"
+LLM_MAX_TOKENS="32768"
+
+# Print usage
+usage() {
+    echo "Usage: $0 --llm_model_name <name> --vlm_model_name <name> [--port <port_number>] [--vlm_port <port>] [--llm_port <port>] [--vlm_host <host>] [--llm_host <host>]"
+    echo "  Example:"
+    echo "    $0 \\"
+    echo "      --llm_model_name deepseek-coder \\"
+    echo "      --vlm_model_name docev_preview \\"
+    echo "      --port 35000 \\"
+    echo "      --vlm_port 35001 \\"
+    echo "      --llm_port 35002"
+    exit 1
+}
+
+# Initialize variables
+LLM_MODEL_NAME=""
+VLM_MODEL_NAME=""
+
+# Parse keyword arguments
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --llm_model_name)
+            LLM_MODEL_NAME="$2"
+            shift 2
+            ;;
+        --vlm_model_name)
+            VLM_MODEL_NAME="$2"
+            shift 2
+            ;;
+        --port)
+            PORT="$2"
+            shift 2
+            ;;
+        --vlm_port)
+            VLM_PORT="$2"
+            shift 2
+            ;;
+        --llm_port)
+            LLM_PORT="$2"
+            shift 2
+            ;;
+        --vlm_host)
+            VLM_HOST="$2"
+            shift 2
+            ;;
+        --llm_host)
+            LLM_HOST="$2"
+            shift 2
+            ;;
+        --vlm_max_tokens)
+            VLM_MAX_TOKENS="$2"
+            shift 2
+            ;;
+        --llm_max_tokens)
+            LLM_MAX_TOKENS="$2"
+            shift 2
+            ;;
+        --help)
+            usage
+            ;;
+        *)
+            echo "Unknown argument: $1"
+            usage
+            ;;
+    esac
+done
+
+# Ensure required arguments are provided
+if [[ -z "$LLM_MODEL_NAME" || -z "$VLM_MODEL_NAME" ]]; then
+    echo "Error: --llm_model_name and --vlm_model_name are required."
+    usage
+fi
+
+# Count the number of GPUs specified
+NUM_PROCESSES=1
+
+# Extract the part after the last slash for log directory naming
+LLM_MODEL_NAME_SHORT=$(echo "$LLM_MODEL_NAME" | awk -F'/' '{print $NF}')
+VLM_MODEL_NAME_SHORT=$(echo "$VLM_MODEL_NAME" | awk -F'/' '{print $NF}')
+
+# Generate the output path automatically using the short names
+OUTPUT_PATH="./logs/${LLM_MODEL_NAME_SHORT}___${VLM_MODEL_NAME_SHORT}" 
+
+mkdir -p "${OUTPUT_PATH}" # Ensure the directory exists
+
+# Construct model arguments string
+MODEL_ARGS="vlm_model_name=${VLM_MODEL_NAME},llm_model_name=${LLM_MODEL_NAME},vlm_host=${VLM_HOST},llm_host=${LLM_HOST},vlm_port=${VLM_PORT},llm_port=${LLM_PORT},vlm_max_completion_tokens=${VLM_MAX_TOKENS},llm_max_completion_tokens=${LLM_MAX_TOKENS}"
+
+# Show the command that will be executed
+echo "Executing command with:"
+echo "  - LLM Model Name: ${LLM_MODEL_NAME}"  
+echo "  - VLM Model Name: ${VLM_MODEL_NAME}"
+echo "  - VLM Host: ${VLM_HOST}"
+echo "  - LLM Host: ${LLM_HOST}"
+echo "  - VLM Port: ${VLM_PORT}"
+echo "  - LLM Port: ${LLM_PORT}"
+echo "  - Output Path: ${OUTPUT_PATH}"
+echo "  - GPU IDs: ${GPU_IDS}"
+echo "  - Port: ${PORT}"
+
+# Run the command
+CMD="python3 -m accelerate.commands.launch \
+    --num_processes ${NUM_PROCESSES} \
+    --gpu_ids ${GPU_IDS} \
+    --mixed_precision bf16 \
+    --main_process_port ${PORT} \
+    -m lmms_eval \
+    --model ${MODEL_NAME} \
+    --model_args ${MODEL_ARGS} \
+    --tasks ${TASKS} \
+    --log_samples \
+    --output_path ${OUTPUT_PATH}"
+
+echo "Command: $CMD"
+
+$CMD
+
+# Remove temp images
+echo "Remove temp images"
+rm -r temp_images/*
+echo "Done"


### PR DESCRIPTION
###  관련자료
- [KIE bench v3.1 구축 노션페이지](https://www.notion.so/upstage/lmms-eval-KIE-bench-v3-1-1e5e45d0002580f281bfda7634fa645c?pvs=4)

---

<img width="728" alt="image" src="https://github.com/user-attachments/assets/f818c571-f3a8-4c83-9914-884dd973951f" />

## VLM + LLM을 이용한 IE 파이프라인 구축

### 구현 방식
- vllm 백엔드를 사용하는 형태로 구현했습니다.
- lmms eval 자체적으로 구현되어 있는 vllm 백엔드는 커스텀 모델 (DocEV DP) 추가 시 라이브러리 내부 코드를 고쳐야하는 문제가 있어, vllm server API에 post request를 보내는 방식으로 구현하였습니다. 
- 따라서, 모델 평가를 위해서는 (1) VLM, LLM 각각 vllm server를 키고 (2) vllm server의 host, port 번호를 입력해 실행해야합니다. README에 작성하였습니다.

### 기존 이슈 일부 해결
<img width="728" alt="image" src="https://github.com/user-attachments/assets/3767d492-701f-4e62-a832-acf4f9f8260c" />

- vllm API call 형태로 구현하면서, schema 입력을 통해 정해진 포맷으로 출력이 나오게끔 지정하는 것이 가능해졌습니다. `info-extractor-engine` repo의 IE pipeline과 거의 흡사한 형태로 작동하는 것이 가능해졌습니다.

## 테스트
현재 아래 코드로 layout viewer를 위해 켜져있는 서버에 테스트 가능합니다. 
코드 동작 테스트는 2개 데이터만 있는 샘플 데이터셋에 이루어졌습니다. 
```
bash scripts/run_eval_VLM_LLM_IE.sh \
  --vlm_model_name "Qwen/Qwen2.5-VL-32B-Instruct" \
  --llm_model_name "Qwen/Qwen2.5-VL-32B-Instruct" \
  --vlm_port 8002 \
  --llm_port 8002 \
  --vlm_host "192.168.1.5" \
  --llm_host "192.168.1.5" \
  --vlm_max_tokens 32768 \
  --llm_max_tokens 32768 \
  --port 8000 
```
- (참고) 위 코드로 테스트시 동일한 GPU에서 VLM/LLM 모두 작동시키는 것이라 느리지만, 서로 다른 GPU 에서 동작하는 VLM, LLM 사용시 더 빠릅니다.

## TODO
- 추후에 평가 속도가 너무 느리다면, 여러 vllm server에 API call을 전달하여 batch processing하는 코드를 추가할 수 있을 것 같습니다.